### PR TITLE
Add background color for avatar in dark mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -70,4 +70,5 @@
 .avatar {
   border-radius: var(--ifm-card-border-radius);
   box-shadow: var(--ifm-global-shadow-lw);
+  background-color: var(--ifm-card-background-color);
 }


### PR DESCRIPTION
Rajouter un fond pour les avatars en dark mode

Avant:
<img width="800" alt="Capture d’écran 2020-10-16 à 10 46 54" src="https://user-images.githubusercontent.com/42354334/96236896-e965a680-0f9c-11eb-947c-c8ff79bd0c1e.png">

Après:
<img width="825" alt="Capture d’écran 2020-10-16 à 10 47 22" src="https://user-images.githubusercontent.com/42354334/96236948-fa161c80-0f9c-11eb-9672-c24c6f9f1452.png">

