### PR TITLE
Fix footer on mobile

### DIFF
--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -12,7 +12,7 @@ const MyPage = () => {
       permalink="/"
       title={siteConfig.title}
       description={siteConfig.tagline}>
-      <div className="hero h-100 text--center">
+      <div className="hero text--center">
         <div className="container ">
           <div className="padding-vert--md">
             <h1 className="hero__title">Qui sommes-nous ?</h1>


### PR DESCRIPTION
J'ai juste enlevé la classe `h-100` qui équivalait à `height: calc(100vh - 150px);`
Cette classe est utile quand on veut que notre contenant remplisse la page  (ex: une div avec slogan et call to action -> la page d'accueil). Mais dans le cas de la page `help.js` le contenu dépasse des 100% du viewport, ce qui décale tout.
Plus d'infos ici pour l'usage des viewports : [https://www.sitepoint.com/css-viewport-units-quick-start/](https://www.sitepoint.com/css-viewport-units-quick-start/)

Avant: 
![Screenshot_2020-10-18 Women On Rails Women On Rails(1)](https://user-images.githubusercontent.com/38593370/96365235-59139700-113f-11eb-82a2-2ee5f1ef2df8.png)

Après: 
![Screenshot_2020-10-18 Women On Rails Women On Rails](https://user-images.githubusercontent.com/38593370/96365242-62046880-113f-11eb-8689-59e6ff9a4609.png)

