### PR TITLE
Remove dead links in katas

### DIFF
--- a/website/docs/find_a_job/katas.mdx
+++ b/website/docs/find_a_job/katas.mdx
@@ -46,7 +46,7 @@ Heureusement de nombreux sites permettent de s'entraîner !<br/>
   <HorizontalCard
     src='/img/find_a_job/katas/prw.png'
     alt='Logo Paris Ruby Workshop'
-    href='http://www.parisrubyworkshop.org/'
+    href='https://github.com/ParisRubyWorkshop'
     title='Paris Ruby Workshop'
     description="Recensement d'exercices en ruby par niveau (débutant, intermédiaire, expert)."
   />
@@ -115,16 +115,6 @@ On en croise de plusieurs types:
       />
     </div>
   </div>
-  <div class="row mt-2">
-    <div class="col col--4">
-      <Avatar
-        src='/img/find_a_job/katas/trustpair.jpg'
-        alt='Trustpair'
-        href='https://github.com/trustpair/jobs/tree/master/ruby/'
-        title='Trustpair'
-      />
-    </div>
-  </div>
 </div>
 
 ## Pour aller plus loin
@@ -139,12 +129,6 @@ Pour finir, des sites plus généralistes en algorithmie, pas centrés sur un la
     description="Ce dossier en ligne a pour but d'aider à préparer un entretien en algorithmie."
   />
   <HorizontalCard
-    src='/img/find_a_job/katas/coding_interviews.png'
-    href='https://github.com/jayshah19949596/CodingInterviews'
-    title='CodingInterviews'
-    description="Des questions techniques posées dans des entreprises telles que VISA, Coursera, Apple..."
-  />
-  <HorizontalCard
     src='/img/find_a_job/katas/interviews_school.png'
     alt='Logo Interviews.school'
     href='https://interviews.school/'
@@ -154,7 +138,7 @@ Pour finir, des sites plus généralistes en algorithmie, pas centrés sur un la
   <HorizontalCard
     src='/img/find_a_job/katas/tech_interview_handbook.svg'
     alt='Logo Tech Interview Handbook'
-    href='https://yangshun.github.io/tech-interview-handbook/algorithms/algorithms-introduction'
+    href='https://www.techinterviewhandbook.org/'
     title='Tech Interview Handbook'
     description="Référence de nombreux sujets d'algorithmie et liste des questions qui peuvent tomber sur chaque sujet."
   />


### PR DESCRIPTION
## Pourquoi cette Pull Request ?
Mettre à jour la page katas

## Qu'est-ce qui a été changé ?
Quelques liens ont été enlevés:

<img width="759" alt="Screenshot 2024-08-14 at 13 55 50" src="https://github.com/user-attachments/assets/ed9ea85b-1d71-4179-b120-633884821bf4">
